### PR TITLE
Bugfix: Mismatch in number of fields

### DIFF
--- a/mp_battery_scrape.py
+++ b/mp_battery_scrape.py
@@ -91,7 +91,7 @@ def scrape_battery_data_to_csv(working_ion, output_filename, apikey):
                     'Charged_ID',
                     'Reduced_Cell_Formula',
                     'Type',
-                    'Spacegroup',
+                    #'Spacegroup',
                     'Average_Voltage',
                     'Capacity_Grav',
                     'Capacity_Vol',


### PR DESCRIPTION
Spacegroup-symbol was expected as a field name in scraped data, but is not extracted from the service